### PR TITLE
feature/#98: mypage calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "moment": "2.30.1",
     "next": "14.2.1",
     "react": "^18",
+    "react-calendar": "5.0.0",
     "react-daum-postcode": "3.1.3",
     "react-dom": "^18",
     "react-hook-form": "^7.51.4",

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,8 @@
-import { LearnProfileProps, MyPageInfoProps } from '@/types/mypage';
+import {
+  CalendarParams,
+  LearnProfileProps,
+  MyPageInfoProps,
+} from '@/types/mypage';
 
 import { BASE_URL } from '.';
 
@@ -212,5 +216,30 @@ export const postMyReview = async (content: string, id: number) => {
     return res;
   } catch (err) {
     throw err;
+  }
+};
+
+// 마이페이지 - 마이페이지 캘린더 조회
+export const getMyCalendar = async (readCalenderReq: CalendarParams) => {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/users/mypage/calender?year=${readCalenderReq.year}&month=${readCalenderReq.month}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${sessionStorage.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch data');
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    throw error;
   }
 };

--- a/src/app/chaemin/cal/page.tsx
+++ b/src/app/chaemin/cal/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import '@/styles/calendar.css';
+import 'react-calendar/dist/Calendar.css';
+
+import { useEffect, useMemo, useState } from 'react';
+import Calendar from 'react-calendar';
+
+import { useMyCalendar } from '@/hooks/api/useMyPage';
+import { MyCalendarListItem } from '@/types/mypage';
+
+import moment from 'moment';
+
+export default function MyCalendarTestPage() {
+  const [date, setDate] = useState(new Date());
+  //   const setCalendarDate = useSetRecoilState(selectedDate);
+
+  const month = moment(date).format('MM');
+
+  useEffect(() => {
+    // setCalendarDate(month);
+  }, [month]);
+
+  const handleDateChange = (newDate: Date) => {
+    setDate(newDate);
+  };
+
+  const { data } = useMyCalendar({
+    year: 2024,
+    month: 5,
+  });
+
+  const toMeetList: MyCalendarListItem[] = useMemo(
+    () => data?.appointments ?? [],
+    [data],
+  );
+
+  console.log('toMeetList', toMeetList);
+
+  return (
+    <div className="flex w-full border border-black">
+      <Calendar
+        formatDay={(locale, date) => moment(date).format('D')}
+        locale="ko"
+        onChange={() => handleDateChange}
+        value={date}
+        calendarType="gregory"
+        next2Label={null} // +1년 & +10년 이동 버튼 숨기기
+        prev2Label={null} // -1년 & -10년 이동 버튼 숨기기
+      />
+    </div>
+  );
+}

--- a/src/app/chaemin/cal/page.tsx
+++ b/src/app/chaemin/cal/page.tsx
@@ -1,80 +1,9 @@
-'use client';
-
-import '@/styles/calendar.css';
-import 'react-calendar/dist/Calendar.css';
-
-import { useEffect, useMemo, useState } from 'react';
-import Calendar from 'react-calendar';
-
-import { useMyCalendar } from '@/hooks/api/useMyPage';
-import { MyCalendarListItem } from '@/types/mypage';
-
-import moment from 'moment';
+import MyCalendar from '@/components/mypage/MyCalendar';
 
 export default function MyCalendarTestPage() {
-  const [date, setDate] = useState(new Date());
-  //   const setCalendarDate = useSetRecoilState(selectedDate);
-
-  const month = moment(date).format('MM');
-
-  useEffect(() => {
-    // setCalendarDate(month);
-  }, [month]);
-
-  const handleDateChange = (newDate: Date) => {
-    setDate(newDate);
-  };
-
-  const { data } = useMyCalendar({
-    year: 2024,
-    month: 5,
-  });
-
-  const toMeetList: MyCalendarListItem[] = useMemo(
-    () => data?.appointments ?? [],
-    [data],
-  );
-
-  console.log('toMeetList', toMeetList);
-
-  const dateList = useMemo(
-    () => toMeetList.map((appointment) => appointment.date),
-    [toMeetList],
-  );
-
   return (
-    <div className="flex w-full border border-black">
-      <Calendar
-        formatDay={(locale, date) => moment(date).format('D')}
-        locale="ko"
-        onChange={() => handleDateChange}
-        value={date}
-        calendarType="gregory"
-        next2Label={null}
-        prev2Label={null}
-        tileContent={({ date, view }) => {
-          if (
-            view === 'month' &&
-            dateList.includes(moment(date).format('YYYY-MM-DD'))
-          ) {
-            const toMeetItems = toMeetList.filter(
-              (item) =>
-                moment(item.date).format('YYYY-MM-DD') ===
-                moment(date).format('YYYY-MM-DD'),
-            );
-            console.log('sisi', toMeetItems);
-            return (
-              <div className="flex justify-center items-center absoluteDiv">
-                {toMeetItems.map((item, index) => (
-                  <div key={index} className="appointment">
-                    {item.tag}
-                  </div>
-                ))}
-              </div>
-            );
-          }
-        }}
-      />
+    <div className="w-full border border-red-500">
+      <MyCalendar />
     </div>
   );
 }

--- a/src/app/chaemin/cal/page.tsx
+++ b/src/app/chaemin/cal/page.tsx
@@ -37,6 +37,11 @@ export default function MyCalendarTestPage() {
 
   console.log('toMeetList', toMeetList);
 
+  const dateList = useMemo(
+    () => toMeetList.map((appointment) => appointment.date),
+    [toMeetList],
+  );
+
   return (
     <div className="flex w-full border border-black">
       <Calendar
@@ -45,8 +50,30 @@ export default function MyCalendarTestPage() {
         onChange={() => handleDateChange}
         value={date}
         calendarType="gregory"
-        next2Label={null} // +1년 & +10년 이동 버튼 숨기기
-        prev2Label={null} // -1년 & -10년 이동 버튼 숨기기
+        next2Label={null}
+        prev2Label={null}
+        tileContent={({ date, view }) => {
+          if (
+            view === 'month' &&
+            dateList.includes(moment(date).format('YYYY-MM-DD'))
+          ) {
+            const toMeetItems = toMeetList.filter(
+              (item) =>
+                moment(item.date).format('YYYY-MM-DD') ===
+                moment(date).format('YYYY-MM-DD'),
+            );
+            console.log('sisi', toMeetItems);
+            return (
+              <div className="flex justify-center items-center absoluteDiv">
+                {toMeetItems.map((item, index) => (
+                  <div key={index} className="appointment">
+                    {item.tag}
+                  </div>
+                ))}
+              </div>
+            );
+          }
+        }}
       />
     </div>
   );

--- a/src/app/mypage/calendar/page.tsx
+++ b/src/app/mypage/calendar/page.tsx
@@ -9,7 +9,7 @@ export default function MyPageCalendar() {
       <div className="pt-[60px] inline-flex flex-col gap-[30px] ml-[282px] pl-6">
         <MyPageTitle
           title="나의 일정 확인하기"
-          content="요거 바꿔야함 통해 얻은 경험 내역을 확인해보세요"
+          content="활동, 배움 일정을 한 눈에 확인할 수 있어요"
         />
         <MyCalendar />
       </div>

--- a/src/app/mypage/calendar/page.tsx
+++ b/src/app/mypage/calendar/page.tsx
@@ -1,0 +1,18 @@
+import MyCalendar from '@/components/mypage/MyCalendar';
+import MyPageTitle from '@/components/mypage/MypageTItle';
+import Sidebar from '@/components/mypage/Sidebar';
+
+export default function MyPageCalendar() {
+  return (
+    <div className="w-full m-auto max-w-[1200px]">
+      <Sidebar />
+      <div className="pt-[60px] inline-flex flex-col gap-[30px] ml-[282px] pl-6">
+        <MyPageTitle
+          title="나의 일정 확인하기"
+          content="요거 바꿔야함 통해 얻은 경험 내역을 확인해보세요"
+        />
+        <MyCalendar />
+      </div>
+    </div>
+  );
+}

--- a/src/app/mypage/point/page.tsx
+++ b/src/app/mypage/point/page.tsx
@@ -7,6 +7,7 @@ import MyPageTitle from '@/components/mypage/MypageTItle';
 import Sidebar from '@/components/mypage/Sidebar';
 
 import { pointNotice } from '@/constants/object';
+import { useNotifySuccess } from '@/hooks/useToast';
 
 import { formatDate } from '@/utils';
 
@@ -44,7 +45,10 @@ export default function MyPoint() {
                 <span className="text-primary-orange6">300</span>
                 포인트
               </span>
-              <span className="flex gap-[6px] items-center text-gray-07 text-notification-chip-no">
+              <span
+                onClick={() => useNotifySuccess('초기화가 완료되었습니다.')}
+                className="cursor-pointer flex gap-[6px] items-center text-gray-07 text-notification-chip-no"
+              >
                 초기화 <GrPowerReset />
               </span>
             </div>

--- a/src/components/common-components/common/Header.tsx
+++ b/src/components/common-components/common/Header.tsx
@@ -5,7 +5,7 @@ import { CgProfile } from 'react-icons/cg';
 import { HiOutlineCurrencyDollar } from 'react-icons/hi2';
 import { VscBell } from 'react-icons/vsc';
 
-import { useNotifyLogin } from '@/hooks/useToast';
+import { useNotifyLater, useNotifyLogin } from '@/hooks/useToast';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -86,11 +86,14 @@ export default function Header({ isGuest }: { isGuest: boolean }) {
 
           {accessToken ? (
             <div className={variants.rightBar}>
-              <div className={variants.rightMenu}>
+              <div
+                className={variants.rightMenu}
+                onClick={() => useNotifyLater()}
+              >
                 <VscBell width={20} height={20} />
                 <span className="pl-[4px]">알림</span>
               </div>
-              <Link href="/mypage">
+              <Link href="/mypage/calendar">
                 <span className={variants.rightMenu}>
                   <CgProfile width={20} height={20} />
                   <span className="pl-[4px]">마이페이지</span>

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -48,7 +48,7 @@ export default function MyCalendar() {
   );
 
   return (
-    <div className="flex flex-col w-full border border-black">
+    <div className="flex flex-col w-full">
       <Calendar
         formatDay={(locale, date) => moment(date).format('D')}
         locale="ko"
@@ -113,7 +113,18 @@ export default function MyCalendar() {
               >
                 {item?.tag}
               </span>
-              <span className="text-body2 ml-4">{item?.description}</span>
+              <span
+                className={clsx(
+                  'text-body2 ml-4',
+                  item?.description.includes('배움 나누기') &&
+                    'text-secondary-violet7',
+                  item?.description.includes('약속') && 'text-[#EFBA00]',
+                  item?.description.includes('활동 참여') &&
+                    'text-primary-orange6',
+                )}
+              >
+                {item?.description}
+              </span>
               <span className="text-body2"> - </span>
               <span className="text-body2">{item?.about}</span>
             </div>

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -1,0 +1,37 @@
+import 'react-calendar/dist/Calendar.css';
+
+import { useEffect, useState } from 'react';
+import Calendar from 'react-calendar';
+
+import { useMyCalendar } from '@/hooks/api/useMyPage';
+
+import moment from 'moment';
+
+export default function MyCalendar() {
+  const [date, setDate] = useState(new Date());
+  //   const setCalendarDate = useSetRecoilState(selectedDate);
+
+  const month = moment(date).format('MM');
+
+  useEffect(() => {
+    // setCalendarDate(month);
+  }, [month]);
+
+  const handleDateChange = (newDate: Date) => {
+    setDate(newDate);
+  };
+
+  //
+  const { data } = useMyCalendar({
+    year: 2024,
+    month: 5,
+  });
+
+  console.log('calendar', data);
+
+  return (
+    <div>
+      <Calendar locale="ko" onChange={() => handleDateChange} value={date} />
+    </div>
+  );
+}

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -9,27 +9,23 @@ import Calendar from 'react-calendar';
 import { useMyCalendar } from '@/hooks/api/useMyPage';
 import { MyCalendarListItem } from '@/types/mypage';
 
+import clsx from 'clsx';
 import moment from 'moment';
 
 export default function MyCalendar() {
   const [date, setDate] = useState(new Date());
-  //   const setCalendarDate = useSetRecoilState(selectedDate);
 
-  const month = moment(date).format('MM');
+  const month = Number(moment(date).format('MM'));
+  const year = Number(moment(date).format('YYYY'));
 
-  useEffect(() => {
-    // setCalendarDate(month);
-  }, [month]);
+  console.log('date', month, year);
 
-  const handleDateChange = (newDate: Date) => {
-    console.log('hihi', newDate);
-    setDate(newDate);
-  };
-
-  const { data } = useMyCalendar({
-    year: 2024,
-    month: 5,
+  const { data, isLoading } = useMyCalendar({
+    year: year,
+    month: month,
   });
+
+  useEffect(() => {}, [month]);
 
   const toMeetList: MyCalendarListItem[] = useMemo(
     () => data?.appointments ?? [],
@@ -48,7 +44,7 @@ export default function MyCalendar() {
       <Calendar
         formatDay={(locale, date) => moment(date).format('D')}
         locale="ko"
-        onChange={() => handleDateChange}
+        onChange={(value) => setDate(value as Date)}
         value={date}
         calendarType="gregory"
         next2Label={null}
@@ -65,9 +61,20 @@ export default function MyCalendar() {
             );
             console.log('sisi', toMeetItems);
             return (
-              <div className="flex justify-center items-center absoluteDiv">
+              <div className="w-full flex flex-col items-center">
                 {toMeetItems.map((item, index) => (
-                  <div key={index} className="">
+                  <div
+                    key={index}
+                    className={clsx(
+                      'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
+                      item.description.includes('배움 나누기') &&
+                        'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
+                      item.description.includes('약속') &&
+                        'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
+                      item.description.includes('활동 참여') &&
+                        'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
+                    )}
+                  >
                     {item.tag}
                   </div>
                 ))}

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -19,8 +19,6 @@ export default function MyCalendar() {
   const month = Number(moment(date).format('MM'));
   const year = Number(moment(date).format('YYYY'));
 
-  console.log('date', month, year);
-
   const { data, isLoading, isPlaceholderData } = useMyCalendar({
     year: year,
     month: month,
@@ -42,7 +40,7 @@ export default function MyCalendar() {
     [data],
   );
 
-  console.log('toMeetList', toMeetList);
+  // console.log('toMeetList', toMeetList);
 
   const dateList = useMemo(
     () => toMeetList.map((appointment) => appointment.date),
@@ -69,7 +67,6 @@ export default function MyCalendar() {
                 moment(item.date).format('YYYY-MM-DD') ===
                 moment(date).format('YYYY-MM-DD'),
             );
-            console.log('sisi', toMeetItems);
             return (
               <div className="w-full flex flex-col items-center">
                 {toMeetItems.map((item, index) => {
@@ -117,7 +114,7 @@ export default function MyCalendar() {
                 {item?.tag}
               </span>
               <span className="text-body2 ml-4">{item?.description}</span>
-              <span> - </span>
+              <span className="text-body2"> - </span>
               <span className="text-body2">{item?.about}</span>
             </div>
           );

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -97,12 +97,29 @@ export default function MyCalendar() {
           }
         }}
       />
-      <div> selected date : {moment(date).format('YYYY년 MM월 DD일')}</div>
-      <div>
-        <span>{selectedData?.date}</span>
-        <span>{selectedData?.description}</span>
-        <span>{selectedData?.about}</span>
-        <span>{selectedData?.tag}</span>
+
+      <div className="my-[30px]">
+        <p className="text-black text-footer-bold mb-7">
+          {moment(date).format('YYYY년 MM월 DD일')}
+        </p>
+        <div>
+          <span
+            className={clsx(
+              'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
+              selectedData?.description.includes('배움 나누기') &&
+                'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
+              selectedData?.description.includes('약속') &&
+                'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
+              selectedData?.description.includes('활동 참여') &&
+                'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
+            )}
+          >
+            {selectedData?.tag}
+          </span>
+          <span className="text-body2 ml-4">{selectedData?.description}</span>
+          <span> - </span>
+          <span className="text-body2">{selectedData?.about}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -20,7 +20,7 @@ export default function MyCalendar() {
 
   console.log('date', month, year);
 
-  const { data, isLoading } = useMyCalendar({
+  const { data, isLoading, isPlaceholderData } = useMyCalendar({
     year: year,
     month: month,
   });

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -14,7 +14,7 @@ import moment from 'moment';
 
 export default function MyCalendar() {
   const [date, setDate] = useState(new Date());
-  const [selectedData, setSelectedData] = useState<MyCalendarListItem>();
+  const [selectedData, setSelectedData] = useState<MyCalendarListItem[]>([]);
 
   const month = Number(moment(date).format('MM'));
   const year = Number(moment(date).format('YYYY'));
@@ -30,10 +30,11 @@ export default function MyCalendar() {
 
   useEffect(() => {
     const selectedDateStr = moment(date).format('YYYY-MM-DD');
-    const selectedAppointment = data?.appointments.find(
-      (appointment) => appointment.date === selectedDateStr,
-    );
-    setSelectedData(selectedAppointment);
+    const selectedAppointments =
+      data?.appointments.filter(
+        (appointment) => appointment.date === selectedDateStr,
+      ) ?? [];
+    setSelectedData(selectedAppointments);
   }, [date, data]);
 
   const toMeetList: MyCalendarListItem[] = useMemo(
@@ -72,9 +73,6 @@ export default function MyCalendar() {
             return (
               <div className="w-full flex flex-col items-center">
                 {toMeetItems.map((item, index) => {
-                  // if (item.date === moment(date).format('YYYY-MM-DD')) {
-                  //   setSelectedData(item);
-                  // }
                   return (
                     <div
                       key={index}
@@ -102,24 +100,28 @@ export default function MyCalendar() {
         <p className="text-black text-footer-bold mb-7">
           {moment(date).format('YYYY년 MM월 DD일')}
         </p>
-        <div>
-          <span
-            className={clsx(
-              'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
-              selectedData?.description.includes('배움 나누기') &&
-                'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
-              selectedData?.description.includes('약속') &&
-                'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
-              selectedData?.description.includes('활동 참여') &&
-                'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
-            )}
-          >
-            {selectedData?.tag}
-          </span>
-          <span className="text-body2 ml-4">{selectedData?.description}</span>
-          <span> - </span>
-          <span className="text-body2">{selectedData?.about}</span>
-        </div>
+        {selectedData?.map((item, idx) => {
+          return (
+            <div>
+              <span
+                className={clsx(
+                  'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
+                  item?.description.includes('배움 나누기') &&
+                    'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
+                  item?.description.includes('약속') &&
+                    'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
+                  item?.description.includes('활동 참여') &&
+                    'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
+                )}
+              >
+                {item?.tag}
+              </span>
+              <span className="text-body2 ml-4">{item?.description}</span>
+              <span> - </span>
+              <span className="text-body2">{item?.about}</span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -1,9 +1,13 @@
+'use client';
+
+import '@/styles/calendar.css';
 import 'react-calendar/dist/Calendar.css';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Calendar from 'react-calendar';
 
 import { useMyCalendar } from '@/hooks/api/useMyPage';
+import { MyCalendarListItem } from '@/types/mypage';
 
 import moment from 'moment';
 
@@ -18,20 +22,61 @@ export default function MyCalendar() {
   }, [month]);
 
   const handleDateChange = (newDate: Date) => {
+    console.log('hihi', newDate);
     setDate(newDate);
   };
 
-  //
   const { data } = useMyCalendar({
     year: 2024,
     month: 5,
   });
 
-  console.log('calendar', data);
+  const toMeetList: MyCalendarListItem[] = useMemo(
+    () => data?.appointments ?? [],
+    [data],
+  );
+
+  console.log('toMeetList', toMeetList);
+
+  const dateList = useMemo(
+    () => toMeetList.map((appointment) => appointment.date),
+    [toMeetList],
+  );
 
   return (
-    <div>
-      <Calendar locale="ko" onChange={() => handleDateChange} value={date} />
+    <div className="flex flex-col w-full border border-black">
+      <Calendar
+        formatDay={(locale, date) => moment(date).format('D')}
+        locale="ko"
+        onChange={() => handleDateChange}
+        value={date}
+        calendarType="gregory"
+        next2Label={null}
+        prev2Label={null}
+        tileContent={({ date, view }) => {
+          if (
+            view === 'month' &&
+            dateList.includes(moment(date).format('YYYY-MM-DD'))
+          ) {
+            const toMeetItems = toMeetList.filter(
+              (item) =>
+                moment(item.date).format('YYYY-MM-DD') ===
+                moment(date).format('YYYY-MM-DD'),
+            );
+            console.log('sisi', toMeetItems);
+            return (
+              <div className="flex justify-center items-center absoluteDiv">
+                {toMeetItems.map((item, index) => (
+                  <div key={index} className="">
+                    {item.tag}
+                  </div>
+                ))}
+              </div>
+            );
+          }
+        }}
+      />
+      <div> selected date : {moment(date).format('YYYY년 MM월 DD일')}</div>
     </div>
   );
 }

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -68,7 +68,7 @@ export default function MyCalendar() {
                 moment(date).format('YYYY-MM-DD'),
             );
             return (
-              <div className="w-full flex flex-col items-center">
+              <div className="w-[120%] -ml-2 flex flex-col justify-center items-center">
                 {toMeetItems.map((item, index) => {
                   return (
                     <div

--- a/src/components/mypage/MyCalendar.tsx
+++ b/src/components/mypage/MyCalendar.tsx
@@ -14,6 +14,7 @@ import moment from 'moment';
 
 export default function MyCalendar() {
   const [date, setDate] = useState(new Date());
+  const [selectedData, setSelectedData] = useState<MyCalendarListItem>();
 
   const month = Number(moment(date).format('MM'));
   const year = Number(moment(date).format('YYYY'));
@@ -26,6 +27,14 @@ export default function MyCalendar() {
   });
 
   useEffect(() => {}, [month]);
+
+  useEffect(() => {
+    const selectedDateStr = moment(date).format('YYYY-MM-DD');
+    const selectedAppointment = data?.appointments.find(
+      (appointment) => appointment.date === selectedDateStr,
+    );
+    setSelectedData(selectedAppointment);
+  }, [date, data]);
 
   const toMeetList: MyCalendarListItem[] = useMemo(
     () => data?.appointments ?? [],
@@ -62,28 +71,39 @@ export default function MyCalendar() {
             console.log('sisi', toMeetItems);
             return (
               <div className="w-full flex flex-col items-center">
-                {toMeetItems.map((item, index) => (
-                  <div
-                    key={index}
-                    className={clsx(
-                      'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
-                      item.description.includes('배움 나누기') &&
-                        'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
-                      item.description.includes('약속') &&
-                        'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
-                      item.description.includes('활동 참여') &&
-                        'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
-                    )}
-                  >
-                    {item.tag}
-                  </div>
-                ))}
+                {toMeetItems.map((item, index) => {
+                  // if (item.date === moment(date).format('YYYY-MM-DD')) {
+                  //   setSelectedData(item);
+                  // }
+                  return (
+                    <div
+                      key={index}
+                      className={clsx(
+                        'mt-[2px] w-full py-[7px] px-2 rounded-[15px] border text-chip-semibold-sm text-start',
+                        item.description.includes('배움 나누기') &&
+                          'bg-secondary-violet2 border-secondary-violet7 text-secondary-violet7',
+                        item.description.includes('약속') &&
+                          'bg-[#FFF8DD] border-chip-creative text-[#EFBA00]',
+                        item.description.includes('활동 참여') &&
+                          'bg-primary-orange2 border-primary-orange5 text-primary-orange6',
+                      )}
+                    >
+                      {item.tag}
+                    </div>
+                  );
+                })}
               </div>
             );
           }
         }}
       />
       <div> selected date : {moment(date).format('YYYY년 MM월 DD일')}</div>
+      <div>
+        <span>{selectedData?.date}</span>
+        <span>{selectedData?.description}</span>
+        <span>{selectedData?.about}</span>
+        <span>{selectedData?.tag}</span>
+      </div>
     </div>
   );
 }

--- a/src/components/mypage/Sidebar.tsx
+++ b/src/components/mypage/Sidebar.tsx
@@ -56,7 +56,12 @@ export default function Sidebar() {
 
       {/* 메뉴 부분 */}
       <div>
-        <ul className={sidebarStyle.ul}>나의 일정 확인하기</ul>
+        <ul
+          onClick={() => router.push('/mypage/calendar')}
+          className={sidebarStyle.ul}
+        >
+          나의 일정 확인하기
+        </ul>
         <ul
           onClick={() => router.push('/mypage/activity')}
           className={sidebarStyle.ul}

--- a/src/hooks/api/useMyPage.ts
+++ b/src/hooks/api/useMyPage.ts
@@ -133,9 +133,11 @@ export const usePostMyReview = (content: string, id: number) => {
 };
 
 export const useMyCalendar = (param: CalendarParams) => {
-  const { data, isLoading, error } = useQuery<MyCalendarResponse>({
-    queryKey: ['myCalendar', param],
-    queryFn: () => getMyCalendar(param),
-  });
-  return { data, isLoading, error };
+  const { data, isLoading, error, isPlaceholderData } =
+    useQuery<MyCalendarResponse>({
+      queryKey: ['myCalendar', param],
+      queryFn: () => getMyCalendar(param),
+      placeholderData: (prev, _) => prev,
+    });
+  return { data, isLoading, error, isPlaceholderData };
 };

--- a/src/hooks/api/useMyPage.ts
+++ b/src/hooks/api/useMyPage.ts
@@ -134,7 +134,7 @@ export const usePostMyReview = (content: string, id: number) => {
 
 export const useMyCalendar = (param: CalendarParams) => {
   const { data, isLoading, error } = useQuery<MyCalendarResponse>({
-    queryKey: ['myCalendar'],
+    queryKey: ['myCalendar', param],
     queryFn: () => getMyCalendar(param),
   });
   return { data, isLoading, error };

--- a/src/hooks/api/useMyPage.ts
+++ b/src/hooks/api/useMyPage.ts
@@ -1,10 +1,16 @@
 import { useGlobalModal } from '@/components/common-components/global-modal';
 
-import { LearnProfileProps, MyPageInfoProps } from '@/types/mypage';
+import {
+  CalendarParams,
+  LearnProfileProps,
+  MyCalendarResponse,
+  MyPageInfoProps,
+} from '@/types/mypage';
 
 import {
   getLearnProfile,
   getMyActivities,
+  getMyCalendar,
   getMyPageInfo,
   getMyReviews,
   getRecievedReviews,
@@ -124,4 +130,12 @@ export const usePostMyReview = (content: string, id: number) => {
     },
   });
   return { mutate, isPending, error };
+};
+
+export const useMyCalendar = (param: CalendarParams) => {
+  const { data, isLoading, error } = useQuery<MyCalendarResponse>({
+    queryKey: ['myCalendar'],
+    queryFn: () => getMyCalendar(param),
+  });
+  return { data, isLoading, error };
 };

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,10 +1,10 @@
 .react-calendar {
   width: 100% !important;
   height: 100%;
-  max-width: 1000px !important;
-  padding: 20px;
+  /* max-width: 1000px !important; */
+  /* padding: 20px; */
   border-radius: 40px;
-  /* border: 1px solid #a4a4a4; */
+  border: none !important;
 }
 
 /* 네비게이션 가운데 정렬 */

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -26,7 +26,9 @@
 .react-calendar__navigation button:enabled:hover,
 .react-calendar__navigation button:enabled:focus {
   background-color: #eee;
-  border-radius: 50px;
+  border-radius: 10px;
+  padding: 4px 8px;
+  border-box: box-sizing;
 }
 
 /* 년/월 상단 네비게이션 칸 크기 줄이기 */

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -59,7 +59,7 @@
 
 /* 일 날짜 간격 */
 .react-calendar__tile {
-  padding: 14px 10px !important;
+  padding: 14px !important;
   box-sizing: border-box !important;
   /* width: 120px !important; */
   height: 166px !important;

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,0 +1,82 @@
+.react-calendar {
+  width: 100%;
+  height: 100%;
+  /* max-width: 900px; */
+  padding: 20px;
+  border-radius: 40px;
+  border: 1px solid #a4a4a4;
+}
+
+/* 네비게이션 가운데 정렬 */
+.react-calendar__navigation {
+  justify-content: start;
+}
+
+.react-calendar__navigation {
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 30px; /* 125% */
+  letter-spacing: 0.48px;
+  color: #14191e;
+}
+
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #eee;
+  border-radius: 50px;
+}
+
+/* 년/월 상단 네비게이션 칸 크기 줄이기 */
+.react-calendar__navigation__label {
+  flex-grow: 0 !important;
+}
+
+.react-calendar__month-view__weekdays {
+  color: #14191e;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 30px; /* 166.667% */
+  letter-spacing: 0.36px;
+}
+
+/* 요일 밑줄 제거 */
+.react-calendar__month-view__weekdays abbr {
+  text-decoration: none;
+}
+
+.react-calendar__month-view__days__day--weekend {
+  color: black;
+}
+
+/* 일 날짜 간격 */
+.react-calendar__tile {
+  padding: 200px;
+  /* height: 166px; */
+  /* position: relative; */
+}
+
+//현재 날짜
+  .react-calendar__tile--now {
+  background: transparent;
+  color: black;
+  font-weight: bold;
+
+  /* border: 1px solid #757575; */
+  /* border-radius: 100%; */
+}
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #e6e6e6;
+}
+
+.react-calendar__tile--active {
+  background: #c3b09e;
+  color: white;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #c3b09e;
+}

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,7 +1,7 @@
 .react-calendar {
-  width: 100%;
+  width: 100% !important;
   height: 100%;
-  /* max-width: 900px; */
+  max-width: 900px !important;
   padding: 20px;
   border-radius: 40px;
   border: 1px solid #a4a4a4;
@@ -46,26 +46,40 @@
   text-decoration: none;
 }
 
+.react-calendar__month-view__days {
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr) !important;
+  /* justify-content: start; */
+  gap: 10px !important;
+}
+
 .react-calendar__month-view__days__day--weekend {
   color: black;
 }
 
 /* 일 날짜 간격 */
 .react-calendar__tile {
-  padding: 200px;
-  /* height: 166px; */
-  /* position: relative; */
+  padding: 14px !important;
+  box-sizing: border-box !important;
+  /* width: 120px !important; */
+  height: 166px !important;
+  background: #f6f6f6 !important;
+  border-radius: 30px !important;
+
+  display: flex !important;
+  align-items: start !important;
 }
 
-//현재 날짜
-  .react-calendar__tile--now {
+/* 현재 날짜*/
+.react-calendar__tile--now {
   background: transparent;
-  color: black;
+  color: pink !important;
   font-weight: bold;
 
   /* border: 1px solid #757575; */
   /* border-radius: 100%; */
 }
+
 .react-calendar__tile--now:enabled:hover,
 .react-calendar__tile--now:enabled:focus {
   background: #e6e6e6;

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -5,6 +5,7 @@
   /* padding: 20px; */
   border-radius: 40px;
   border: none !important;
+  font-family: 'var(--font-wantedSans)';
 }
 
 /* 네비게이션 가운데 정렬 */
@@ -19,6 +20,7 @@
   line-height: 30px; /* 125% */
   letter-spacing: 0.48px;
   color: #14191e;
+  font-family: 'var(--font-wantedSans)';
 }
 
 .react-calendar__navigation button:enabled:hover,
@@ -39,11 +41,14 @@
   font-weight: 500;
   line-height: 30px; /* 166.667% */
   letter-spacing: 0.36px;
+  font-family: 'var(--font-wantedSans)';
 }
 
 /* 요일 밑줄 제거 */
 .react-calendar__month-view__weekdays abbr {
   text-decoration: none;
+  font-size: 18px;
+  font-family: 'var(--font-wantedSans)';
 }
 
 .react-calendar__month-view__days {
@@ -51,6 +56,7 @@
   grid-template-columns: repeat(7, 1fr) !important;
   /* justify-content: start; */
   gap: 10px !important;
+  font-family: 'var(--font-wantedSans)';
 }
 
 .react-calendar__month-view__days__day--weekend {
@@ -61,7 +67,7 @@
 .react-calendar__tile {
   padding: 14px !important;
   box-sizing: border-box !important;
-  /* width: 120px !important; */
+  width: 120px !important;
   height: 166px !important;
   background: #f6f6f6 !important;
   border-radius: 30px !important;
@@ -80,7 +86,7 @@
 /* 현재 날짜*/
 .react-calendar__tile--now {
   background: transparent;
-  color: black !important;
+  color: #fa7328 !important;
   font-weight: bold;
   border: 1px solid #fa7328 !important;
   /* border: 1px solid #757575; */

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,7 +1,7 @@
 .react-calendar {
   width: 100% !important;
   height: 100%;
-  max-width: 900px !important;
+  max-width: 1000px !important;
   padding: 20px;
   border-radius: 40px;
   border: 1px solid #a4a4a4;
@@ -59,7 +59,7 @@
 
 /* 일 날짜 간격 */
 .react-calendar__tile {
-  padding: 14px !important;
+  padding: 14px 10px !important;
   box-sizing: border-box !important;
   /* width: 120px !important; */
   height: 166px !important;
@@ -67,13 +67,29 @@
   border-radius: 30px !important;
 
   display: flex !important;
+  flex-direction: column !important;
   align-items: start !important;
+
+  font-size: 18px !important;
+  font-style: normal !important;
+  font-weight: 600 !important;
+  line-height: 30px !important; /* 166.667% */
+  letter-spacing: 0.36px !important;
 }
 
 /* 현재 날짜*/
 .react-calendar__tile--now {
   background: transparent;
-  color: pink !important;
+  color: black !important;
+  font-weight: bold;
+  border: 1px solid #fa7328 !important;
+  /* border: 1px solid #757575; */
+  /* border-radius: 100%; */
+}
+
+.react-calendar__tile:hover {
+  background: #feddcb !important;
+  color: black !important;
   font-weight: bold;
 
   /* border: 1px solid #757575; */
@@ -82,15 +98,17 @@
 
 .react-calendar__tile--now:enabled:hover,
 .react-calendar__tile--now:enabled:focus {
-  background: #e6e6e6;
+  background: #feddcb !important;
+  color: #fa7328 !important;
 }
 
 .react-calendar__tile--active {
-  background: #c3b09e;
-  color: white;
+  background: #feddcb !important;
+  color: #fa7328 !important;
 }
 
 .react-calendar__tile--active:enabled:hover,
 .react-calendar__tile--active:enabled:focus {
-  background: #c3b09e;
+  background: #feddcb;
+  color: #fa7328 !important;
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -4,7 +4,7 @@
   max-width: 1000px !important;
   padding: 20px;
   border-radius: 40px;
-  border: 1px solid #a4a4a4;
+  /* border: 1px solid #a4a4a4; */
 }
 
 /* 네비게이션 가운데 정렬 */

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -32,3 +32,19 @@ export interface ReviewsByMeItem {
 export interface ReviewsByMeResponse {
   reviews: ReviewsByMeItem[];
 }
+
+export type CalendarParams = {
+  year: number;
+  month: number;
+};
+
+export interface MyCalendarListItem {
+  data: string;
+  tag: string;
+  description: string;
+  about: string;
+}
+
+export interface MyCalendarResponse {
+  appointments: MyCalendarListItem[];
+}

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -39,7 +39,7 @@ export type CalendarParams = {
 };
 
 export interface MyCalendarListItem {
-  data: string;
+  date: string;
   tag: string;
   description: string;
   about: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,6 +495,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@wojtekmaj/date-utils@^1.1.3":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz#c3cd67177ac781cfa5736219d702a55a2aea5f2b"
+  integrity sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -835,6 +840,11 @@ client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 clsx@^2.1.0:
   version "2.1.0"
@@ -1567,6 +1577,13 @@ get-tsconfig@^4.5.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
+get-user-locale@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/get-user-locale/-/get-user-locale-2.3.2.tgz#d37ae6e670c2b57d23a96fb4d91e04b2059d52cf"
+  integrity sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==
+  dependencies:
+    mem "^8.0.0"
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -2120,7 +2137,7 @@ lodash@^4.17.12, lodash@^4.17.19, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2139,6 +2156,21 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+map-age-cleaner@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
+mem@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
+  integrity sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.1.0"
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -2156,6 +2188,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
+  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 minimatch@9.0.3:
   version "9.0.3"
@@ -2374,6 +2411,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
+
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
@@ -2555,6 +2597,16 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-calendar@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-5.0.0.tgz#cf302db689ee1bba53d92644f7543e12164a7c0e"
+  integrity sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    warning "^4.0.0"
 
 react-daum-postcode@3.1.3:
   version "3.1.3"
@@ -3249,6 +3301,13 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+warning@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 websocket-driver@>=0.5.1:
   version "0.7.4"


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #98 


## 🔨변경 사항(Changes)
- `react-calendar` 라이브러리 설치
- 캘린더 컴포넌트 MyCalendar 추가
- api 연동 완료

**[남은 이슈]**
- 내비게이션 버튼 클릭 시 이전 혹은 다음 달의 일정을 바로 패칭이 불가합니다.
- 예를 들어, 5월 30일의 일정은 6월에서도 보여야 하는데 다음 및 이전 달 이동 시 이전의 데이터가 사라지고 해당 '월'의 데이터 resposne만 보이고 있습니다.

## 😉리뷰 요구사항
- 위에 작성한 이슈와 관련해서 의견이나 피드백이 있다면 말씀해주세요~!
- 아직 피그마랑 완전 똑같게 커스텀을 하지 않은 상태라 로직 먼저 봐주시면 좋을 것 같아요. 더 효율적으로 작성할 수 있을 것 같은데,, 흑
- 일정이 잘 패칭되는지 테스트해주시면 좋을 것 같아요.

## 💎확인 방법 (선택)



<br/>

---
### 📌 PR 진행 시 이러한 점들을 참고해 주세요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)

